### PR TITLE
Fix for Dockerfile smell DL3003

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM thraxil/django.base:2022-09-11-fd03dfc6c7a5
 COPY docker-run.sh /run.sh
 COPY package.json /node/
-RUN cd /node && npm install && touch /node/node_modules/sentinal
+WORKDIR /node 
+RUN  npm install && touch /node/node_modules/sentinal
 COPY requirements.txt /app/requirements.txt
 RUN /ve/bin/pip3 install -r /app/requirements.txt && touch /ve/sentinal
 WORKDIR /app


### PR DESCRIPTION
Hi!
The Dockerfile placed at "Dockerfile" contains the best practice violation [DL3003](https://github.com/hadolint/hadolint/wiki/DL3003) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3003 occurs if the pattern `RUN cd ...` is used to change directories instead of the dedicated WORKDIR instruction.
This pull request proposes a fix for that smell generated by my fixing tool. The patch was manually verified before opening the pull request. To fix this smell, specifically, the pattern `RUN cd ...` is replaced with the equivalent WORKDIR instruction.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance